### PR TITLE
Switch to Underscore Templates while keeping "mustache" style syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 public/css/style.css
 .idea
 npm-debug.log
+.project

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,8 @@ module.exports = function(grunt) {
           exports: true,
           define: true,
           require: true,
-          Backbone: true
+          Backbone: true,
+          window: true
         }
       }
     },
@@ -53,12 +54,27 @@ module.exports = function(grunt) {
           out: "public/js/app.built.js"
         }
       }
+    },
+    jst: {
+      compile: {
+        options: {
+          templateSettings: {
+            evaluate:    /\{\{(.+?)\}\}/g,
+            interpolate: /\{\{=(.+?)\}\}/g,
+            escape:      /\{\{-(.+?)\}\}/g
+          }
+        },
+        files: {
+          "public/tmpl/templates.js": ["public/tmpl/**/*.html"]
+        }
+      }
     }
   });
 
   grunt.loadNpmTasks('grunt-contrib-nodeunit');
+  grunt.loadNpmTasks('grunt-contrib-jst');
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
-  grunt.registerTask('default', ['jshint', 'requirejs']);
+  grunt.registerTask('default', ['jshint', 'requirejs', 'jst']);
 
 };

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 var express = require('express');
+var engines = require('consolidate');
 var routes = require('./routes');
 var http = require('http');
 var path = require('path');
@@ -9,7 +10,8 @@ var nib = require('nib');
 app.configure(function(){
   app.set('port', process.env.PORT || 3000);
   app.set('views', __dirname + '/views');
-  app.set('view engine', 'hjs');
+  app.engine('html', engines.underscore);
+  app.set('view engine', 'html');
   app.use(express.favicon());
   app.use(express.logger('dev'));
   app.use(express.bodyParser());

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "express": "3.0.0rc3",
+    "consolidate": "*",
     "hjs": "*",
     "stylus": "*",
     "underscore": "~1.3.3",

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,14 +1,25 @@
 require.config({
+  shim: {     
+    underscoreBase: {
+      exports: '_'
+    },
+    underscore: {
+      deps: ['underscoreBase'],
+      exports: '_'
+    }
+  },
   paths: {
     jquery: "lib/zepto.min",
-    underscore: "lib/lodash.custom.min",
     backbone: "lib/backbone-min",
+    underscoreBase: "lib/lodash.custom.min",
+    underscore: "lib/underscoreSettings",
+    text: "lib/text",
     hbs: "lib/hbs",
     i18nprecompile: "lib/i18nprecompile",
     handlebars: "lib/Handlebars"
   },
   hbs : {
-	  disableI18n: true
+    disableI18n: true
   }
 });
 

--- a/public/js/lib/underscoreSettings.js
+++ b/public/js/lib/underscoreSettings.js
@@ -1,0 +1,8 @@
+define(['underscoreBase'], function(_) {
+  _.templateSettings = {
+    evaluate:    /\{\{(.+?)\}\}/g,
+    interpolate: /\{\{=(.+?)\}\}/g,
+    escape:      /\{\{-(.+?)\}\}/g
+  };
+  return _;
+});

--- a/public/js/view/deck.js
+++ b/public/js/view/deck.js
@@ -1,11 +1,24 @@
+//define(function(require) {
+//  var Backbone = require('backbone');
+//  var _ = require('underscore');
+//  var template = require('text!../../tmpl/deck.html');
+//  return Backbone.View.extend({
+//    template: _.template(template),
+//    render: function() {
+//      this.el = this.template(this.model.toJSON());
+//      return this;
+//    }
+//  });
+//});
+
 define(function(require) {
-	var Backbone = require('backbone')
-	var template = require('hbs!../../tmpl/deck')
-	return Backbone.View.extend({
-	  template: template,
-	  render: function() {
-	    this.el = this.template(this.model.toJSON());
-	    return this;
-	  }
-	});
+  var Backbone = require('backbone'),
+      template = require('../../tmpl/templates');
+  return Backbone.View.extend({
+    render: function() {
+      this.template = window['JST']['public/tmpl/deck.html'](this.model.toJSON()),
+      this.el = this.template;
+      return this;
+    }
+  });
 });

--- a/public/js/view/slide.js
+++ b/public/js/view/slide.js
@@ -1,11 +1,24 @@
+//define(function(require) {
+//  var Backbone = require('backbone');
+//  var _ = require('underscore');
+//  var template = require('text!../../tmpl/slide.html');
+//  return Backbone.View.extend({
+//    template: _.template(template),
+//    render: function() {
+//      this.el = this.template(this.model.toJSON());
+//      return this;
+//    }
+//  });
+//});
+
 define(function(require) {
-	var Backbone = require('backbone')
-	var template = require('hbs!../../tmpl/slide')
-	return Backbone.View.extend({
-	  template: template,
-	  render: function() {
-	    this.el = this.template(this.model.toJSON());
-	    return this;
-	  }
-	})
-})
+  var Backbone = require('backbone'),
+      template = require('../../tmpl/templates');
+  return Backbone.View.extend({
+    render: function() {
+      this.template = window['JST']['public/tmpl/slide.html'](this.model.toJSON()),
+      this.el = this.template;
+      return this;
+    }
+  });
+});

--- a/public/tmpl/deck.html
+++ b/public/tmpl/deck.html
@@ -1,0 +1,6 @@
+<a href="#decks/{{=id}}">
+	<article class="deck">
+		<h2>{{=title}}</h2>
+		<div class="r sub">{{=author}}</div>
+	</article>
+</a>

--- a/public/tmpl/slide.html
+++ b/public/tmpl/slide.html
@@ -1,0 +1,8 @@
+<a href="#slides/{{=deckId}}/{{=num}}">
+<article class="slide">
+	{{if (typeof img != 'undefined') { }}
+		<img src="{{=img}}" class="slide-thumb">
+	{{ } }}
+	<h2 class="slide-title">{{=title}}</h2>
+</article>
+</a>

--- a/public/tmpl/templates.js
+++ b/public/tmpl/templates.js
@@ -1,0 +1,40 @@
+this["JST"] = this["JST"] || {};
+
+this["JST"]["public/tmpl/deck.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape;
+with (obj) {
+__p += '<a href="#decks/' +
+((__t = (id)) == null ? '' : __t) +
+'">\n\t<article class="deck">\n\t\t<h2>' +
+((__t = (title)) == null ? '' : __t) +
+'</h2>\n\t\t<div class="r sub">' +
+((__t = (author)) == null ? '' : __t) +
+'</div>\n\t</article>\n</a>\n';
+
+}
+return __p
+};
+
+this["JST"]["public/tmpl/slide.html"] = function(obj) {
+obj || (obj = {});
+var __t, __p = '', __e = _.escape, __j = Array.prototype.join;
+function print() { __p += __j.call(arguments, '') }
+with (obj) {
+__p += '<a href="#slides/' +
+((__t = (deckId)) == null ? '' : __t) +
+'/' +
+((__t = (num)) == null ? '' : __t) +
+'">\n<article class="slide">\n\t';
+if (typeof img != 'undefined') { ;
+__p += '\n\t\t<img src="' +
+((__t = (img)) == null ? '' : __t) +
+'" class="slide-thumb">\n\t';
+ } ;
+__p += '\n\t<h2 class="slide-title">' +
+((__t = (title)) == null ? '' : __t) +
+'</h2>\n</article>\n</a>\n';
+
+}
+return __p
+};


### PR DESCRIPTION
I managed to use underscore templates keeping <code>{{ }}</code> syntax with the way you suggested (using require-jst to precompile templates).

I also manage to do so without require-jst. 

I added consolodate.js to use underscore as view engine with express.js and  configuring underscore templates setting to use <code>{{ }}</code> syntax.

<pre>
_.templateSettings = {
    evaluate:    /\{\{(.+?)\}\}/g,
    interpolate: /\{\{=(.+?)\}\}/g,
    escape:      /\{\{-(.+?)\}\}/g
  };
</pre>


Under view scripts (deck.js and slide.js) I implemented both methods (the non-precompiled method is commented). Application and dependencies configurations need some fixing now that handlebars are not required but I didn't "dig into" that. 

The new tempates are deck.html and slide.html and when run the task <code>$ grunt jst</code> the precompiled templates are under <code>/public/tmpl/templates.js</code>

I registed the task to run when compiling with grunt.
